### PR TITLE
feat: implement access control for admin and author roles

### DIFF
--- a/controller/articleController.js
+++ b/controller/articleController.js
@@ -3,14 +3,14 @@ const newsModel = require('../models/News');
 const userModel = require('../models/User');
 
 const allArticle = async (req,res) => {
-    res.render('admin/articles')
+    res.render('admin/articles',{ role: req.role })
 }
 const addArticlePage = async (req,res) => {
-    res.render('admin/articles/create')
+    res.render('admin/articles/create',{ role: req.role })
 }
 const addArticle = async (req,res) => {}
 const updateArticlePage = async (req,res) => {
-    res.render('admin/articles/update')
+    res.render('admin/articles/update',{ role: req.role })
 }
 const updateArticle = async (req,res) => {}
 const deleteArticle = async (req,res) => {}

--- a/controller/categoryController.js
+++ b/controller/categoryController.js
@@ -1,18 +1,18 @@
 const mongoose = require('mongoose')
 
 const allCategory = async (req,res) => {
-    res.render('admin/categories')
+    res.render('admin/categories',{ role: req.role })
 }
 const addCategoryPage = async (req,res) => {
-    res.render('admin/categories/create')
+    res.render('admin/categories/create',{ role: req.role })
 }
 const addCategory = async (req,res) => {
-    
 }
-const updateCategoryPage = async (req,res) => {}
-const updateCategory = async (req,res) => {
-    res.render('admin/categories/update')
+const updateCategoryPage = async (req,res) => {
+     res.render('admin/categories/update',{ role: req.role })
 }
+const updateCategory = async (req,res) => {}
+   
 const deleteCategory = async (req,res) => {}
 
 module.exports = {

--- a/controller/commentController.js
+++ b/controller/commentController.js
@@ -2,7 +2,7 @@ const commentModel   = require('../models/Comment');
 
 
 const allComments = async (req,res) => {
-    res.render('admin/comments')
+    res.render('admin/comments',{ role: req.role })
 }
 
 module.exports = {

--- a/controller/userController.js
+++ b/controller/userController.js
@@ -22,7 +22,7 @@ try{
         return res.status(401).send('Invalid username and password')
     }
 
-    const jwtData= { id: user._id, fullName: user.fullName, role: user.role}
+    const jwtData= { id: user._id, fullName: user.fullname, role: user.role}
     const token = jwt.sign(jwtData, process.env.JWT_SECRET, { expiresIn: '1h' } );
     res.cookie('token', token, { httpOnly: true, maxAge: 60 * 60 * 1000});
     res.render('admin/dashboard')
@@ -37,7 +37,7 @@ const logout = async(req,res) => {
     res.redirect('/admin/')
 }
 const dashboard = async(req,res) => {
-    res.render('admin/dashboard')
+    res.render('admin/dashboard',{ role: req.role })
 }
 const settings = async(req,res) => {
     res.render('admin/settings')
@@ -45,12 +45,12 @@ const settings = async(req,res) => {
 
 const allUser = async(req,res) => {
     const users = await(userModel.find())
-    res.render('admin/users', { users })
+    res.render('admin/users', { users, role: req.role })
 }
 
 
 const addUserPage = async(req,res) => {
-    res.render('admin/users/create')
+    res.render('admin/users/create',{ role: req.role })
 }
 const addUser = async(req,res) => {
      await userModel.create(req.body)
@@ -63,7 +63,7 @@ try {
     if(!user){
         return res.status(404).send('User not found')
     }
-    res.render('admin/users/update',{ user })
+    res.render('admin/users/update',{ user, role: req.role })
     } catch (error) {
         console.log(error);
         res.status(500).send('Internal Server Error')

--- a/middleware/isAdmin.js
+++ b/middleware/isAdmin.js
@@ -1,0 +1,9 @@
+const isAdmin = (req, res, next) => {
+    if (req.role === 'admin') {
+        next();
+    } else {
+        res.redirect('/admin/dashboard');
+    }
+};
+
+module.exports = isAdmin;

--- a/middleware/isLoggedin.js
+++ b/middleware/isLoggedin.js
@@ -5,6 +5,11 @@ const isLoggedIn = async(req, res, next) => {
         const token = req.cookies.token;
         if(!token) return res.redirect('/admin/');
         const tokenData = jwt.verify(token, process.env.JWT_SECRET);
+       console.log(tokenData);
+       
+    req.fullname = tokenData.fullName;
+    req.role = tokenData.role;
+   
         next();
     }catch(error){
         res.status(401).send('Unauthorized: Invalid token');

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -6,42 +6,43 @@ const categoryController = require('../controller/categoryController');
 const articleController = require('../controller/articleController');
 const commentController = require('../controller/commentController');
 const isLoggedIn = require('../middleware/isLoggedin');
+const isAdmin = require('../middleware/isAdmin');
 
 //Login Routes
 router.get('/', userController.loginPage);
 router.post('/index', userController.adminLogin);
 router.get('/logout', userController.logout);
 router.get('/dashboard', isLoggedIn, userController.dashboard);
-router.get('/settings', isLoggedIn, userController.settings);
+router.get('/settings', isLoggedIn, isAdmin, userController.settings);
 
 //User CRUD Routes
 //Display all users
-router.get('/users', isLoggedIn, userController.allUser);
+router.get('/users', isLoggedIn, isAdmin, userController.allUser);
 //Open Add user page
-router.get('/add-user', isLoggedIn, userController.addUserPage);
+router.get('/add-user', isLoggedIn, isAdmin, userController.addUserPage);
 //Save Add user page
-router.post('/add-user', isLoggedIn, userController.addUser);
+router.post('/add-user', isLoggedIn, isAdmin, userController.addUser);
 
 //Open update user page
-router.get('/update-user/:id', isLoggedIn, userController.updateUserPage);
+router.get('/update-user/:id', isLoggedIn, isAdmin, userController.updateUserPage);
 //Save Update user page
-router.post('/update-user/:id', isLoggedIn, userController.updateUser);
+router.post('/update-user/:id', isLoggedIn, isAdmin, userController.updateUser);
 //Delete user page
-router.delete('/delete-user/:id', isLoggedIn, userController.deleteUser);
+router.delete('/delete-user/:id', isLoggedIn, isAdmin, userController.deleteUser);
  
 //Category CRUD routes
 //Display all categories
-router.get('/category', isLoggedIn, categoryController.allCategory);
+router.get('/category', isLoggedIn, isAdmin, categoryController.allCategory);
 //Open Add category page
-router.get('/add-category', isLoggedIn, categoryController.addCategoryPage);
+router.get('/add-category', isLoggedIn, isAdmin, categoryController.addCategoryPage);
 //Save Add category page
-router.post('/add-category', isLoggedIn, categoryController.addCategory);
+router.post('/add-category', isLoggedIn, isAdmin, categoryController.addCategory);
 //Open update category page
-router.get('/update-category/:id', isLoggedIn, categoryController.updateCategoryPage);
+router.get('/update-category/:id', isLoggedIn, isAdmin, categoryController.updateCategoryPage);
 //Save Update category page
-router.post('/update-category/:id', isLoggedIn, categoryController.updateCategory);
+router.post('/update-category/:id', isLoggedIn, isAdmin, categoryController.updateCategory);
 //Delete category page
-router.delete('/delete-category/:id', isLoggedIn, categoryController.deleteCategory);
+router.delete('/delete-category/:id', isLoggedIn, isAdmin, categoryController.deleteCategory);
 
 
 //Article CRUD route


### PR DESCRIPTION
Added middleware-based role checking to restrict access to certain admin routes. 
- Only users with the 'admin' role can access user and category management pages.
- Authors have limited access (e.g., can create articles but cannot manage users or settings).
- Role information is extracted from JWT and passed via res.locals for layout access.
This ensures unauthorized users are redirected or denied access based on their role.